### PR TITLE
👷 Unblock CI from stuck macos-13 Intel queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-and-typecheck:
     runs-on: ubuntu-latest
@@ -29,14 +33,7 @@ jobs:
       - run: pnpm test
 
   build-mac:
-    strategy:
-      matrix:
-        include:
-          - os: macos-15
-            arch: arm64
-          - os: macos-13
-            arch: x64
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-15
 
     steps:
       - uses: actions/checkout@v4
@@ -53,9 +50,9 @@ jobs:
       - run: pnpm build
 
       - name: Package (unsigned)
-        run: pnpm exec electron-builder --mac --${{ matrix.arch }} --publish never
+        run: pnpm exec electron-builder --mac --x64 --arm64 --publish never
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
 
-      - name: Verify DMG exists
+      - name: Verify DMGs exist
         run: ls -lh dist/*.dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,7 @@ permissions:
 
 jobs:
   build-mac:
-    strategy:
-      matrix:
-        include:
-          - os: macos-15
-            arch: arm64
-          - os: macos-13
-            arch: x64
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-15
 
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +27,7 @@ jobs:
       - run: pnpm build
 
       - name: Build and publish
-        run: pnpm exec electron-builder --mac --${{ matrix.arch }} --publish always
+        run: pnpm exec electron-builder --mac --x64 --arm64 --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.CSC_LINK }}


### PR DESCRIPTION
## Summary

CI has been stuck for hours — the `macos-13` x64 runner pool is severely capacity-constrained (ahead of macos-13 retirement). Only the x64 leg was stalling; ubuntu + macos-15 arm64 completed in under a minute. Every PR push without a concurrency group piled another stuck job onto the queue.

- Drop the `macos-13` matrix leg and build both x64 and arm64 from a single `macos-15` runner via `electron-builder --mac --x64 --arm64` (`better-sqlite3` ships prebuilt binaries for both darwin arches — no native rebuild needed)
- Apply the same collapse to `release.yml` so tag builds don't hit the Intel queue either
- Add a workflow-level `concurrency` group so new pushes cancel superseded runs instead of piling up

Example stall: [run 24536855948](https://github.com/AlanChen4/slowblink/actions/runs/24536855948) — `build-mac (macos-13, x64)` queued 2h+ while the other jobs finished in <1m.

## Test plan

- [ ] First CI run on this PR starts `build-mac` on `macos-15` within seconds (not queued)
- [ ] `Verify DMGs exist` step lists both an `*-arm64.dmg` and an x64/Intel DMG in `dist/`
- [ ] Push a second commit and confirm the first run is canceled by the concurrency group
- [ ] On merge, `main` CI behaves the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)