### PR TITLE
🔖 Bump version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slowblink",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Periodic screenshot activity tracker with LLM summaries",
   "author": {


### PR DESCRIPTION
## Summary
- Bump `package.json` version from `0.1.0` → `0.2.0` to cover the accumulated changes since the last tag (Mac signing/auto-updater removal, CI unblocking on macos-13, dev capture sidebar item, CI publish + Stop hook fixes).

## Test plan
- [ ] `package.json` reports `0.2.0`