### PR TITLE
🔒️ Ad-hoc sign mac builds so arm64 DMGs launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ slowblink runs in your menu bar and captures a screenshot every few seconds (con
 
 1. Download the latest `.dmg` from [GitHub Releases](https://github.com/AlanChen4/slowblink/releases)
 2. Open the DMG and drag slowblink to Applications
-3. Launch slowblink — it will appear in your menu bar
+3. First launch: right-click slowblink in Applications → **Open** → **Open** (builds are unsigned, so macOS needs this one-time override)
+4. slowblink will appear in your menu bar
 
 ## Setup
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -7,6 +7,7 @@ directories:
 files:
   - out/**/*
   - package.json
+afterPack: scripts/ad-hoc-sign.js
 mac:
   category: public.app-category.productivity
   identity: null

--- a/scripts/ad-hoc-sign.js
+++ b/scripts/ad-hoc-sign.js
@@ -1,0 +1,20 @@
+// Ad-hoc sign the packaged .app so downloaded arm64 builds will launch.
+// electron-builder's `identity: null` skips all signing, including the ad-hoc
+// fallback. Apple Silicon refuses to launch an entirely-unsigned app that
+// carries the com.apple.quarantine attribute, showing the misleading
+// "app is damaged and can't be opened" error. An ad-hoc signature is enough
+// to clear that bar; users still see the "unidentified developer" prompt on
+// first launch.
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+exports.default = async function afterPack(context) {
+  if (context.electronPlatformName !== 'darwin') return;
+  const appPath = path.join(
+    context.appOutDir,
+    `${context.packager.appInfo.productFilename}.app`,
+  );
+  execFileSync('codesign', ['--force', '--deep', '--sign', '-', appPath], {
+    stdio: 'inherit',
+  });
+};


### PR DESCRIPTION
## Summary

- Fixes "slowblink.app is damaged and can't be opened" on downloaded arm64 DMGs. After #5 dropped signing, `identity: null` skipped *all* signing including the ad-hoc fallback — Apple Silicon refuses to launch an entirely-unsigned app under quarantine, which is what shows as "damaged."
- Adds `scripts/ad-hoc-sign.js` as an electron-builder `afterPack` hook that runs `codesign --sign -` on the packaged `.app`. No Developer ID, no notarization, no new secrets.
- Updates [README.md](README.md) to document the one-time right-click → Open step users still need (the "unidentified developer" prompt remains — that's expected for an unsigned build).

## Test plan

- [x] `pnpm package:mac` succeeds; `codesign -dv` reports `Signature=adhoc` on both `dist/mac/slowblink.app` (x64) and `dist/mac-arm64/slowblink.app`.
- [x] `codesign --verify --verbose=4` reports "valid on disk" and "satisfies its Designated Requirement" on the arm64 build with a simulated quarantine attribute.
- [ ] Cut a 0.2.1 release and confirm the GitHub-published arm64 DMG launches on a real M-series Mac (right-click → Open on first run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)