### PR TITLE
🐛 Fix stale paused state indicator + add /hunt-bug command

### DIFF
--- a/.claude/commands/hunt-bug.md
+++ b/.claude/commands/hunt-bug.md
@@ -88,17 +88,48 @@ If 4a or 4b fails:
 
 Do not cap the iteration count — keep looping until both pass. If you're stuck after several iterations without progress, report what you've tried and what you need from the user; don't silently give up or declare partial success.
 
-## Phase 6 — Finalize
+## Phase 6 — Simplify
 
 Only after **both** 4a and 4b are clean:
 
 1. Commit the fix (gitmoji `🐛` for bug fix) referring to the failing test now passing.
-2. Report back with: what the bug was, where the divergent state lived, the one-line fix summary, and links to the commits (test commit + fix commit).
-3. If appropriate, run the `/go` skill to open the PR. Otherwise hand off to the user.
+2. **Run `/simplify`** via the `Skill` tool. It launches reuse / quality / efficiency reviewers in parallel against the diff. Apply any actionable fixes; skip false positives. Common catches for bug fixes:
+   - Stale fixtures / dead properties that don't fail the Stop hook because an earlier `&&`-chained step already failed (e.g. `tsc --noEmit -p tsconfig.web.json` is skipped when `tsconfig.node.json` errors first). Run each `tsc -p <config>` separately to confirm.
+   - Over-permissive `| null` prop types that are impossible at the actual call sites.
+   - Redundant cache / refresh calls you added defensively that the existing subscribers already cover.
+3. If `/simplify` applies changes, commit them separately with `♻️`.
+
+## Phase 7 — Open the PR
+
+Push and open (or update) the PR yourself rather than delegating to `/go` — the visual verification from Phase 4b already covers what `/go` would re-run.
+
+1. **Push**: `git push -u origin <branch>` (the branch may be `main` if that's what you're on — check `git status`; if so, push the commits straight to main per the repo convention, otherwise push the feature branch).
+2. **Create or update the PR** with `gh pr create` (or rely on auto-update if a PR already exists on this branch). Title uses a gitmoji matching the primary commit (`🐛 …`). Body:
+   ```
+   ## Summary
+   - The bug, one line.
+   - The root cause, one line.
+   - The fix, one line.
+
+   ## Test plan
+   - [x] New test `<path>` — fails before the fix, passes after.
+   - [x] Visual verification in Electron via agent-browser (describe what you clicked).
+   - [ ] Anything the human should verify manually (packaged build, permission flows).
+   ```
+3. Return the PR URL to the user.
+
+## Phase 8 — Report
+
+End with a concise summary:
+- What the bug was and where the divergent state / root cause lived.
+- Commits (test repro + fix + optional simplify) and the PR link.
+- Any findings from `/simplify` that were applied.
+- Any caveats (tests you couldn't run, follow-ups worth separate PRs).
 
 ## Guardrails
 
 - **Never** mark the task complete while any test fails or while visual verification has not been performed.
 - **Never** skip Phase 4b by claiming the test is sufficient — the user asked for both because tests can pass while the UI is still wrong (e.g. the test mocks away the real state flow).
 - **Never** amend the failing-test commit after fixing. Keep the repro commit intact so the history shows: "test fails" → "fix makes test pass".
-- If the Stop hook runs checks automatically, let it; don't double-run format/lint.
+- **Never** open the PR before running `/simplify` — that skill has caught real issues (dead properties, unused null-permissive types, redundant refresh calls) that would otherwise land in the PR.
+- If the Stop hook runs checks automatically, let it; don't double-run format/lint. But **do** run each `tsc -p <config>` separately once before pushing, since the Stop hook's `&&`-chained typecheck can mask web-config errors when the node-config step fails first.

--- a/.claude/commands/hunt-bug.md
+++ b/.claude/commands/hunt-bug.md
@@ -1,0 +1,104 @@
+---
+description: Autonomous bug-hunting loop — reproduce with a failing test, diagnose, fix, and verify via both the test suite and visual Electron automation. Do not exit until both pass.
+argument-hint: <bug description>
+---
+
+# /hunt-bug — autonomous reproduce → fix → verify loop
+
+You are hunting down a bug end-to-end. The bug:
+
+> $ARGUMENTS
+
+This is a loop, not a linear task. **Do not exit until both the new test passes AND visual verification in the running Electron app confirms correct behavior.** If either check fails, log what you learned and loop back to diagnosis with that new information.
+
+## Phase 1 — Reproduce with a failing test
+
+1. Read the bug description carefully. Identify:
+   - The observable symptom (what the user sees that's wrong).
+   - The smallest scenario that triggers it (what state, what action).
+   - The invariant being violated (what *should* be true but isn't).
+2. Pick the test shape that most directly exercises the invariant:
+   - **Unit / component test** (vitest + `@testing-library/react` under `src/**/*.test.{ts,tsx}`) when the bug lives in a pure function, a component's render, or a well-scoped module. This is the default — prefer it.
+   - **Main-process test** (vitest, `node` env) when the bug is in `src/main/` logic that doesn't need a renderer.
+   - **Electron UI script** (agent-browser via the [electron skill](../skills/electron/SKILL.md)) only when the bug is inherently cross-process and can't be reproduced without the running app. Capture it as a repeatable script or test, not a one-shot manual check.
+3. Write the test so it **fails for the right reason** — it should assert on the invariant, not on the current buggy behavior. Verify the failure by running it (`pnpm test <path>`). If it passes unexpectedly, the reproduction is wrong; fix it before moving on.
+4. Commit the failing test on its own so the repro is recoverable:
+   ```bash
+   git add <test path>
+   git commit -m "$(cat <<'EOF'
+   🧪 Reproduce <short bug name>
+
+   Failing test that asserts <invariant>. Will go green once the fix lands.
+
+   Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+   EOF
+   )"
+   ```
+
+## Phase 2 — Diagnose root cause
+
+Read widely before editing. For state-flow bugs, map all the actors:
+
+- Where does the state *live* (store, module-level var, component state)?
+- Who *reads* it — and from which copy?
+- Who *writes* it — and what broadcasts does that writing trigger?
+- Are there **multiple sources of truth** that can disagree during transitions? This is the pattern behind most "stale indicator" bugs.
+- Are there ordering assumptions between broadcasts/events that aren't guaranteed?
+
+Write the hypothesis down (one or two sentences, in your user-facing update) before writing the fix. If the hypothesis is wrong later, that framing makes it obvious.
+
+## Phase 3 — Implement the fix
+
+Fix the root cause, not the symptom. For state-flow bugs, prefer consolidating sources of truth over adding synchronization logic — fewer places that can disagree is better than more code keeping them in sync.
+
+Scope discipline: don't refactor surrounding code, don't add unrelated guards, don't rename things. A bug fix is a bug fix.
+
+## Phase 4 — Verify (both must pass)
+
+### 4a. Test suite
+
+Run the full suite, not just the new test:
+
+```bash
+pnpm test
+```
+
+The new test must pass. No other test may regress. If the Stop hook runs format/lint/typecheck/knip/test automatically, wait for its verdict and act on any failures before continuing.
+
+### 4b. Visual verification in the running Electron app
+
+Use the [electron skill](../skills/electron/SKILL.md) via agent-browser. Non-negotiable: you are verifying the *real* app, not just the model in the test.
+
+1. Start dev with CDP: `pnpm dev -- --remote-debugging-port=9222` (background). Wait for `DevTools listening on ws://...`. If better-sqlite3 mismatches, rebuild per the electron skill.
+2. Connect via the webSocketDebuggerUrl for the `slowblink` page (see the /go skill for the exact `curl`).
+3. Reproduce the *original* user scenario from Phase 1 through the UI. Click the buttons, toggle the settings, trigger the transition that was broken.
+4. Confirm the visible state is now consistent. Screenshot the key state and check that every UI surface that reflects the bug's domain agrees with every other surface.
+5. Regression sweep: click through nearby UI that touches the same state. A "paused" fix could regress "running" rendering; verify both.
+6. Stop the dev server: `pkill -f "electron-vite"; pkill -f "Electron"`.
+
+If agent-browser can't connect or the flow can't be driven from the UI, say so explicitly — do **not** claim visual verification based on code reading.
+
+## Phase 5 — Loop on failure
+
+If 4a or 4b fails:
+
+1. In your user-facing update, write one or two sentences: *what did I learn from this failure?* Be specific — "the badge still shows Paused for one render after clicking Resume" beats "it didn't work."
+2. Return to Phase 2 with that new information. Your previous hypothesis was incomplete or wrong — refine it before editing again.
+3. Re-run both verifications from scratch after the new fix. Don't skip 4a because "nothing test-relevant changed."
+
+Do not cap the iteration count — keep looping until both pass. If you're stuck after several iterations without progress, report what you've tried and what you need from the user; don't silently give up or declare partial success.
+
+## Phase 6 — Finalize
+
+Only after **both** 4a and 4b are clean:
+
+1. Commit the fix (gitmoji `🐛` for bug fix) referring to the failing test now passing.
+2. Report back with: what the bug was, where the divergent state lived, the one-line fix summary, and links to the commits (test commit + fix commit).
+3. If appropriate, run the `/go` skill to open the PR. Otherwise hand off to the user.
+
+## Guardrails
+
+- **Never** mark the task complete while any test fails or while visual verification has not been performed.
+- **Never** skip Phase 4b by claiming the test is sufficient — the user asked for both because tests can pass while the UI is still wrong (e.g. the test mocks away the real state flow).
+- **Never** amend the failing-test commit after fixing. Keep the repro commit intact so the history shows: "test fails" → "fix makes test pass".
+- If the Stop hook runs checks automatically, let it; don't double-run format/lint.

--- a/src/main/capture.ts
+++ b/src/main/capture.ts
@@ -216,7 +216,6 @@ export function getStatus(): CaptureStatus {
   const s = getSettings();
   return {
     running: timer !== null,
-    paused: s.paused,
     lastError,
     lastCaptureTs,
     hasPermission: hasScreenPermission(),
@@ -228,7 +227,6 @@ export function getStatus(): CaptureStatus {
 function statusEqual(a: CaptureStatus, b: CaptureStatus): boolean {
   return (
     a.running === b.running &&
-    a.paused === b.paused &&
     a.lastError === b.lastError &&
     a.lastCaptureTs === b.lastCaptureTs &&
     a.hasPermission === b.hasPermission &&

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -76,7 +76,7 @@ function createWindow() {
   }
 }
 
-function statusLabel(status: CaptureStatus, settings: Settings): string {
+function trayStatusLabel(status: CaptureStatus, settings: Settings): string {
   if (settings.paused) return 'paused';
   if (status.running) return 'running';
   return 'idle';
@@ -91,16 +91,13 @@ function trayTitle(status: CaptureStatus, settings: Settings): string {
 function buildTrayMenu(status: CaptureStatus, settings: Settings) {
   return Menu.buildFromTemplate([
     {
-      label: `slowblink — ${statusLabel(status, settings)}`,
+      label: `slowblink — ${trayStatusLabel(status, settings)}`,
       enabled: false,
     },
     { type: 'separator' },
     {
       label: settings.paused ? 'Resume capture' : 'Pause capture',
-      click: () => {
-        setSettings({ paused: !settings.paused });
-        refreshTray();
-      },
+      click: () => setSettings({ paused: !settings.paused }),
     },
     { label: 'Open slowblink…', click: () => createWindow() },
     { type: 'separator' },
@@ -113,7 +110,7 @@ function refreshTray() {
   const status = getStatus();
   const settings = getSettings();
   tray.setTitle(trayTitle(status, settings));
-  tray.setToolTip(`slowblink — ${statusLabel(status, settings)}`);
+  tray.setToolTip(`slowblink — ${trayStatusLabel(status, settings)}`);
   tray.setContextMenu(buildTrayMenu(status, settings));
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 import { app, BrowserWindow, Menu, nativeImage, Tray } from 'electron';
-import type { CaptureStatus } from '../shared/types';
+import type { CaptureStatus, Settings } from '../shared/types';
 import { registerProtocolHandler } from './auth/deep-link';
 import { loadSessionFromDisk, onSessionChange } from './auth/session';
 import { initPlanCache, onPlanChange } from './billing/plan-cache';
@@ -24,6 +24,7 @@ import {
 import {
   getSettings,
   initSettings,
+  onSettingsChange,
   refreshSettings,
   setSettings,
 } from './settings';
@@ -75,29 +76,29 @@ function createWindow() {
   }
 }
 
-function statusLabel(s: CaptureStatus): string {
-  if (s.paused) return 'paused';
-  if (s.running) return 'running';
+function statusLabel(status: CaptureStatus, settings: Settings): string {
+  if (settings.paused) return 'paused';
+  if (status.running) return 'running';
   return 'idle';
 }
 
-function trayTitle(s: CaptureStatus): string {
-  if (!s.hasPermission || !s.hasApiKey) return '●!';
-  if (s.paused) return '◌';
+function trayTitle(status: CaptureStatus, settings: Settings): string {
+  if (!status.hasPermission || !status.hasApiKey) return '●!';
+  if (settings.paused) return '◌';
   return '●';
 }
 
-function buildTrayMenu(status: CaptureStatus) {
+function buildTrayMenu(status: CaptureStatus, settings: Settings) {
   return Menu.buildFromTemplate([
     {
-      label: `slowblink — ${statusLabel(status)}`,
+      label: `slowblink — ${statusLabel(status, settings)}`,
       enabled: false,
     },
     { type: 'separator' },
     {
-      label: status.paused ? 'Resume capture' : 'Pause capture',
+      label: settings.paused ? 'Resume capture' : 'Pause capture',
       click: () => {
-        setSettings({ paused: !status.paused });
+        setSettings({ paused: !settings.paused });
         refreshTray();
       },
     },
@@ -109,10 +110,11 @@ function buildTrayMenu(status: CaptureStatus) {
 
 function refreshTray() {
   if (!tray) return;
-  const s = getStatus();
-  tray.setTitle(trayTitle(s));
-  tray.setToolTip(`slowblink — ${statusLabel(s)}`);
-  tray.setContextMenu(buildTrayMenu(s));
+  const status = getStatus();
+  const settings = getSettings();
+  tray.setTitle(trayTitle(status, settings));
+  tray.setToolTip(`slowblink — ${statusLabel(status, settings)}`);
+  tray.setContextMenu(buildTrayMenu(status, settings));
 }
 
 const disposers: (() => void)[] = [];
@@ -146,6 +148,7 @@ app.whenReady().then(async () => {
   tray.on('click', () => createWindow());
 
   disposers.push(onStatusChange(() => refreshTray()));
+  disposers.push(onSettingsChange(() => refreshTray()));
 
   const settings = getSettings();
   const canCapture = settings.aiMode === 'cloud-ai' || settings.hasApiKey;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -118,6 +118,7 @@ export default function App() {
         >
           <StatusBadge
             status={status}
+            settings={settings}
             sync={sync}
             issues={issues}
             onNavigateToApiKey={() => {

--- a/src/renderer/components/StatusBadge.paused-sync.test.tsx
+++ b/src/renderer/components/StatusBadge.paused-sync.test.tsx
@@ -7,7 +7,6 @@ afterEach(cleanup);
 
 const BASE_STATUS: CaptureStatus = {
   running: true,
-  paused: false,
   lastError: null,
   lastCaptureTs: null,
   hasPermission: true,
@@ -27,23 +26,17 @@ const BASE_SETTINGS: Settings = {
   onboardingComplete: true,
 };
 
-// The bug: `status.paused` and `settings.paused` travel to the renderer on two
-// separate IPC channels (`statusUpdate`, `settingsUpdate`). The PauseButton
-// reads `settings.paused`, the StatusBadge reads `status.paused`. During a
-// pause/resume transition the two channels can arrive out of sync, and the
-// renderer shows an inconsistent state — e.g. badge says "Running" while the
-// button offers Resume.
-//
-// Invariant: there is one source of truth for paused. `Settings.paused` is the
-// persisted user intent and should drive both UI surfaces.
+// Regression guard: paused used to live on both `CaptureStatus` and `Settings`
+// and arrive on two separate IPC channels, so the badge (reading status) and
+// the pause button (reading settings) could briefly disagree mid-transition.
+// Settings.paused is now the single source of truth; these tests pin that.
 describe('StatusBadge pause-state source of truth', () => {
-  test('shows "Paused" when settings.paused=true, even while status.paused is stale', () => {
-    const staleStatus: CaptureStatus = { ...BASE_STATUS, paused: false };
+  test('shows "Paused" when settings.paused=true', () => {
     const freshSettings: Settings = { ...BASE_SETTINGS, paused: true };
 
     render(
       <StatusBadge
-        status={staleStatus}
+        status={BASE_STATUS}
         settings={freshSettings}
         sync={null}
         issues={[]}
@@ -53,14 +46,11 @@ describe('StatusBadge pause-state source of truth', () => {
     expect(screen.getByText('Paused')).toBeDefined();
   });
 
-  test('shows live state when settings.paused=false, even while status.paused is stale', () => {
-    const staleStatus: CaptureStatus = { ...BASE_STATUS, paused: true };
-    const freshSettings: Settings = { ...BASE_SETTINGS, paused: false };
-
+  test('shows live state when settings.paused=false', () => {
     render(
       <StatusBadge
-        status={staleStatus}
-        settings={freshSettings}
+        status={BASE_STATUS}
+        settings={BASE_SETTINGS}
         sync={null}
         issues={[]}
       />,

--- a/src/renderer/components/StatusBadge.paused-sync.test.tsx
+++ b/src/renderer/components/StatusBadge.paused-sync.test.tsx
@@ -1,0 +1,72 @@
+import type { CaptureStatus, Settings } from '@shared/types';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, test } from 'vitest';
+import { StatusBadge } from './StatusBadge';
+
+afterEach(cleanup);
+
+const BASE_STATUS: CaptureStatus = {
+  running: true,
+  paused: false,
+  lastError: null,
+  lastCaptureTs: null,
+  hasPermission: true,
+  hasAccessibility: true,
+  hasApiKey: true,
+};
+
+const BASE_SETTINGS: Settings = {
+  intervalMs: 5000,
+  model: 'gpt-5.4-nano',
+  paused: false,
+  hasApiKey: true,
+  apiKeySource: 'saved',
+  apiKeyHint: 'sk-xxx',
+  storageMode: 'local',
+  aiMode: 'byo-key',
+  onboardingComplete: true,
+};
+
+// The bug: `status.paused` and `settings.paused` travel to the renderer on two
+// separate IPC channels (`statusUpdate`, `settingsUpdate`). The PauseButton
+// reads `settings.paused`, the StatusBadge reads `status.paused`. During a
+// pause/resume transition the two channels can arrive out of sync, and the
+// renderer shows an inconsistent state — e.g. badge says "Running" while the
+// button offers Resume.
+//
+// Invariant: there is one source of truth for paused. `Settings.paused` is the
+// persisted user intent and should drive both UI surfaces.
+describe('StatusBadge pause-state source of truth', () => {
+  test('shows "Paused" when settings.paused=true, even while status.paused is stale', () => {
+    const staleStatus: CaptureStatus = { ...BASE_STATUS, paused: false };
+    const freshSettings: Settings = { ...BASE_SETTINGS, paused: true };
+
+    render(
+      <StatusBadge
+        status={staleStatus}
+        settings={freshSettings}
+        sync={null}
+        issues={[]}
+      />,
+    );
+
+    expect(screen.getByText('Paused')).toBeDefined();
+  });
+
+  test('shows live state when settings.paused=false, even while status.paused is stale', () => {
+    const staleStatus: CaptureStatus = { ...BASE_STATUS, paused: true };
+    const freshSettings: Settings = { ...BASE_SETTINGS, paused: false };
+
+    render(
+      <StatusBadge
+        status={staleStatus}
+        settings={freshSettings}
+        sync={null}
+        issues={[]}
+      />,
+    );
+
+    expect(screen.queryByText('Paused')).toBeNull();
+    expect(screen.getByText('Running')).toBeDefined();
+  });
+});

--- a/src/renderer/components/StatusBadge.test.tsx
+++ b/src/renderer/components/StatusBadge.test.tsx
@@ -7,7 +7,6 @@ afterEach(cleanup);
 
 const BASE_STATUS: CaptureStatus = {
   running: true,
-  paused: false,
   lastError: null,
   lastCaptureTs: null,
   hasPermission: true,
@@ -48,7 +47,12 @@ describe('collectIssues', () => {
 describe('StatusBadge', () => {
   test('renders error label with red text when issues are present', () => {
     render(
-      <StatusBadge status={BASE_STATUS} sync={null} issues={['No API Key']} />,
+      <StatusBadge
+        status={BASE_STATUS}
+        settings={BASE_SETTINGS}
+        sync={null}
+        issues={['No API Key']}
+      />,
     );
 
     const label = screen.getByText('No API Key');
@@ -57,7 +61,14 @@ describe('StatusBadge', () => {
   });
 
   test('renders running state with no issues', () => {
-    render(<StatusBadge status={BASE_STATUS} sync={null} issues={[]} />);
+    render(
+      <StatusBadge
+        status={BASE_STATUS}
+        settings={BASE_SETTINGS}
+        sync={null}
+        issues={[]}
+      />,
+    );
 
     expect(screen.getByText('Running')).toBeDefined();
     expect(screen.queryByText(/no api key/i)).toBeNull();
@@ -68,6 +79,7 @@ describe('StatusBadge', () => {
     render(
       <StatusBadge
         status={BASE_STATUS}
+        settings={BASE_SETTINGS}
         sync={null}
         issues={['No API Key']}
         onNavigateToApiKey={onNavigateToApiKey}
@@ -81,7 +93,12 @@ describe('StatusBadge', () => {
 
   test('renders "No API Key" as plain text when no handler is provided', () => {
     render(
-      <StatusBadge status={BASE_STATUS} sync={null} issues={['No API Key']} />,
+      <StatusBadge
+        status={BASE_STATUS}
+        settings={BASE_SETTINGS}
+        sync={null}
+        issues={['No API Key']}
+      />,
     );
 
     expect(screen.queryByRole('button', { name: 'No API Key' })).toBeNull();

--- a/src/renderer/components/StatusBadge.tsx
+++ b/src/renderer/components/StatusBadge.tsx
@@ -50,14 +50,13 @@ export function StatusBadge({
   onNavigateToApiKey,
 }: {
   status: CaptureStatus | null;
-  settings: Settings | null;
+  settings: Settings;
   sync: SyncStatus | null;
   issues: string[];
   onNavigateToApiKey?: () => void;
 }) {
   if (!status) return null;
-  const paused = settings?.paused ?? false;
-  const color = statusColor(status, paused, issues.length > 0);
+  const color = statusColor(status, settings.paused, issues.length > 0);
   const syncPart = sync ? syncLabel(sync) : null;
   const textColor =
     issues.length > 0
@@ -69,7 +68,7 @@ export function StatusBadge({
       {issues.length > 0 ? (
         <IssueList issues={issues} onNavigateToApiKey={onNavigateToApiKey} />
       ) : (
-        statusLabel(status, paused)
+        statusLabel(status, settings.paused)
       )}
       {syncPart && <span className="text-xs">· {syncPart}</span>}
     </div>

--- a/src/renderer/components/StatusBadge.tsx
+++ b/src/renderer/components/StatusBadge.tsx
@@ -16,14 +16,18 @@ export function collectIssues(
   return issues;
 }
 
-function statusColor(status: CaptureStatus, hasIssues: boolean): string {
+function statusColor(
+  status: CaptureStatus,
+  paused: boolean,
+  hasIssues: boolean,
+): string {
   if (hasIssues || status.lastError) return 'bg-destructive';
-  if (status.paused) return 'bg-amber-500';
+  if (paused) return 'bg-amber-500';
   return 'bg-emerald-500';
 }
 
-function statusLabel(status: CaptureStatus): string {
-  if (status.paused) return 'Paused';
+function statusLabel(status: CaptureStatus, paused: boolean): string {
+  if (paused) return 'Paused';
   if (status.lastCaptureTs) {
     return `Last Updated at ${new Date(status.lastCaptureTs).toLocaleTimeString()}`;
   }
@@ -40,17 +44,20 @@ function syncLabel(sync: SyncStatus): string | null {
 
 export function StatusBadge({
   status,
+  settings,
   sync,
   issues,
   onNavigateToApiKey,
 }: {
   status: CaptureStatus | null;
+  settings: Settings | null;
   sync: SyncStatus | null;
   issues: string[];
   onNavigateToApiKey?: () => void;
 }) {
   if (!status) return null;
-  const color = statusColor(status, issues.length > 0);
+  const paused = settings?.paused ?? false;
+  const color = statusColor(status, paused, issues.length > 0);
   const syncPart = sync ? syncLabel(sync) : null;
   const textColor =
     issues.length > 0
@@ -62,7 +69,7 @@ export function StatusBadge({
       {issues.length > 0 ? (
         <IssueList issues={issues} onNavigateToApiKey={onNavigateToApiKey} />
       ) : (
-        statusLabel(status)
+        statusLabel(status, paused)
       )}
       {syncPart && <span className="text-xs">· {syncPart}</span>}
     </div>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -46,7 +46,6 @@ export type SettingsPatch = Partial<
 
 export interface CaptureStatus {
   running: boolean;
-  paused: boolean;
   lastError: string | null;
   lastCaptureTs: number | null;
   hasPermission: boolean;


### PR DESCRIPTION
## Summary

- **Bug**: the top-bar badge could show "Running" while the adjacent button offered "Resume" (or the inverse) for a render or two after clicking pause/resume. `CaptureStatus.paused` and `Settings.paused` were two IPC broadcasts that could arrive in either order, with the badge reading the first and the button reading the second.
- **Fix**: remove `paused` from `CaptureStatus` entirely and have `StatusBadge` derive its label from `settings.paused` — a single source of truth. Tray in the main process now reads `getSettings()` directly and refreshes on settings change as well as status change.
- **Bonus**: new `/hunt-bug <description>` slash command at `.claude/commands/hunt-bug.md` — an autonomous loop that reproduces a bug with a failing test, diagnoses, fixes, and verifies via both `pnpm test` and visual agent-browser automation against the running Electron app. Mandates `/simplify` before opening the PR.

## Test plan

- [x] `src/renderer/components/StatusBadge.paused-sync.test.tsx` — new regression test pinning that the badge follows `settings.paused`. Fails before the fix, passes after.
- [x] Existing `StatusBadge.test.tsx` still passes (7 tests) after `CaptureStatus.paused` removal.
- [x] Visual verification in the running Electron app: clicked Pause → badge "Paused" + Resume button. 6-iteration rapid-toggle stress test via the renderer console kept badge and button in sync every iteration.
- [x] `tsc --noEmit -p tsconfig.web.json` and `tsc --noEmit -p tsconfig.node.json` both clean for the files this PR touches.
- [ ] Human: packaged build still shows the correct tray icon + menu label when toggling pause from the tray.

🤖 Generated with [Claude Code](https://claude.com/claude-code)