### PR TITLE
🚧 Archive WIP Insights feature draft

### DIFF
--- a/src/main/ai/insights-summarizer.ts
+++ b/src/main/ai/insights-summarizer.ts
@@ -1,0 +1,251 @@
+import { generateText, Output } from 'ai';
+import { z } from 'zod';
+import type { Session } from '../../shared/types';
+import { getSamples, getSessions, updateSessionSummary } from '../db';
+
+const SessionSummarySchema = z.object({
+  summary: z
+    .string()
+    .describe(
+      'One or two sentences summarizing what the user was doing during this session and why (if apparent from context).',
+    ),
+});
+
+const DaySummarySchema = z.object({
+  highlights: z
+    .array(z.string())
+    .describe('3-5 main things accomplished or spent time on'),
+  topProjects: z.array(
+    z.object({
+      project: z.string(),
+      durationMinutes: z.number(),
+      description: z.string(),
+    }),
+  ),
+  patterns: z
+    .array(z.string())
+    .describe(
+      'Notable patterns like "spent 2 hours on reddit after lunch" or "context-switched frequently between 2-4pm"',
+    ),
+  categoryBreakdown: z
+    .array(
+      z.object({
+        category: z.string(),
+        minutes: z.number(),
+      }),
+    )
+    .describe('Minutes per category'),
+});
+
+const WeekSummarySchema = z.object({
+  highlights: z
+    .array(z.string())
+    .describe('3-5 key themes or accomplishments for the week'),
+  topProjects: z.array(
+    z.object({
+      project: z.string(),
+      durationMinutes: z.number(),
+      description: z.string(),
+    }),
+  ),
+  trends: z
+    .array(z.string())
+    .describe(
+      'Notable trends compared across days, like "most productive on Tuesday" or "reddit usage increased toward end of week"',
+    ),
+  dailyBreakdown: z.array(
+    z.object({
+      date: z.string(),
+      highlights: z.array(z.string()),
+    }),
+  ),
+});
+
+const MonthSummarySchema = z.object({
+  highlights: z
+    .array(z.string())
+    .describe('3-5 key themes or accomplishments for the month'),
+  topProjects: z.array(
+    z.object({
+      project: z.string(),
+      durationMinutes: z.number(),
+      description: z.string(),
+    }),
+  ),
+  trends: z.array(z.string()).describe('Notable trends across the month'),
+  weeklyBreakdown: z.array(
+    z.object({
+      week: z.string(),
+      highlights: z.array(z.string()),
+    }),
+  ),
+});
+
+export { DaySummarySchema, MonthSummarySchema, WeekSummarySchema };
+
+type ModelFactory = (
+  apiKey: string,
+  modelId: string,
+) => Promise<Parameters<typeof generateText>[0]['model']>;
+
+let getModel: ModelFactory | null = null;
+
+export function setModelFactory(factory: ModelFactory): void {
+  getModel = factory;
+}
+
+async function requireModel(apiKey: string, modelId: string) {
+  if (!getModel)
+    throw new Error('Model factory not set — call setModelFactory first');
+  return getModel(apiKey, modelId);
+}
+
+function selectRepresentativeSamples(
+  samples: import('../../shared/types').Sample[],
+): string[] {
+  const format = (s: import('../../shared/types').Sample) =>
+    `[${s.category}] ${s.activity}${s.detail ? ` (${s.detail})` : ''}`;
+
+  if (samples.length <= 50) return samples.map(format);
+
+  const first5 = samples.slice(0, 5);
+  const last5 = samples.slice(-5);
+  const step = Math.floor(samples.length / 20);
+  const middle = [];
+  for (let i = 5; i < samples.length - 5 && middle.length < 20; i += step) {
+    middle.push(samples[i]);
+  }
+  return [...first5, ...middle, ...last5].map(format);
+}
+
+function findNeighborSessions(session: Session) {
+  const neighbors = getSessions(
+    session.startTs - 4 * 60 * 60 * 1000,
+    session.endTs + 4 * 60 * 60 * 1000,
+  );
+  const idx = neighbors.findIndex((s) => s.id === session.id);
+  return {
+    prev: idx > 0 ? neighbors[idx - 1] : null,
+    next: idx < neighbors.length - 1 ? neighbors[idx + 1] : null,
+  };
+}
+
+export async function summarizeSession(
+  session: Session,
+  apiKey: string,
+  modelId: string,
+): Promise<string> {
+  const samples = getSamples(session.startTs, session.endTs + 1);
+  const sampleActivities = selectRepresentativeSamples(samples);
+  const { prev, next } = findNeighborSessions(session);
+
+  const durationMin = Math.round(session.durationMs / 60000);
+  const app = session.primaryApp ?? 'unknown app';
+  const cat = session.primaryCategory;
+  const project = session.primaryProject
+    ? ` on project "${session.primaryProject}"`
+    : '';
+
+  const prompt = `You are summarizing a computer activity session.
+
+Previous session: ${prev?.summary ?? 'N/A'}
+
+Current session (${durationMin} minutes, primarily ${cat} in ${app}${project}):
+${sampleActivities.join('\n')}
+
+Next session: ${next?.summary ?? 'N/A'}
+
+Write one or two sentences summarizing what the user was doing and why (if apparent from context).`;
+
+  const { output } = await generateText({
+    model: await requireModel(apiKey, modelId),
+    output: Output.object({ schema: SessionSummarySchema }),
+    messages: [{ role: 'user', content: prompt }],
+  });
+
+  const summary = output.summary;
+  updateSessionSummary(session.id, summary, Date.now());
+  return summary;
+}
+
+export async function generateDaySummary(
+  date: string,
+  sessions: Session[],
+  apiKey: string,
+  modelId: string,
+): Promise<z.infer<typeof DaySummarySchema>> {
+  const sessionDescriptions = sessions.map((s) => {
+    const start = new Date(s.startTs).toLocaleTimeString();
+    const end = new Date(s.endTs).toLocaleTimeString();
+    const dur = Math.round(s.durationMs / 60000);
+    const proj = s.primaryProject ? ` [${s.primaryProject}]` : '';
+    return `${start}–${end} (${dur}min): ${s.summary ?? `${s.primaryCategory} in ${s.primaryApp ?? 'unknown'}`}${proj}`;
+  });
+
+  const totalMinutes = Math.round(
+    sessions.reduce((a, s) => a + s.durationMs, 0) / 60000,
+  );
+
+  const prompt = `Summarize this day's computer activity (${date}, ${totalMinutes} total minutes across ${sessions.length} sessions):
+
+${sessionDescriptions.join('\n')}
+
+Provide highlights (3-5 main accomplishments/activities), top projects with durations, notable patterns, and a category breakdown in minutes.`;
+
+  const { output } = await generateText({
+    model: await requireModel(apiKey, modelId),
+    output: Output.object({ schema: DaySummarySchema }),
+    messages: [{ role: 'user', content: prompt }],
+  });
+  return output;
+}
+
+export async function generateWeekSummary(
+  week: string,
+  daySummaries: { date: string; json: z.infer<typeof DaySummarySchema> }[],
+  apiKey: string,
+  modelId: string,
+): Promise<z.infer<typeof WeekSummarySchema>> {
+  const dayDescriptions = daySummaries.map(
+    (d) =>
+      `${d.date}:\n  Highlights: ${d.json.highlights.join('; ')}\n  Top projects: ${d.json.topProjects.map((p) => `${p.project} (${p.durationMinutes}min)`).join(', ')}`,
+  );
+
+  const prompt = `Summarize this week's computer activity (${week}):
+
+${dayDescriptions.join('\n\n')}
+
+Provide weekly highlights, top projects with total durations, trends across days, and a brief daily breakdown.`;
+
+  const { output } = await generateText({
+    model: await requireModel(apiKey, modelId),
+    output: Output.object({ schema: WeekSummarySchema }),
+    messages: [{ role: 'user', content: prompt }],
+  });
+  return output;
+}
+
+export async function generateMonthSummary(
+  month: string,
+  weekSummaries: { week: string; json: z.infer<typeof WeekSummarySchema> }[],
+  apiKey: string,
+  modelId: string,
+): Promise<z.infer<typeof MonthSummarySchema>> {
+  const weekDescriptions = weekSummaries.map(
+    (w) =>
+      `${w.week}:\n  Highlights: ${w.json.highlights.join('; ')}\n  Top projects: ${w.json.topProjects.map((p) => `${p.project} (${p.durationMinutes}min)`).join(', ')}`,
+  );
+
+  const prompt = `Summarize this month's computer activity (${month}):
+
+${weekDescriptions.join('\n\n')}
+
+Provide monthly highlights, top projects with total durations, trends across weeks, and a brief weekly breakdown.`;
+
+  const { output } = await generateText({
+    model: await requireModel(apiKey, modelId),
+    output: Output.object({ schema: MonthSummarySchema }),
+    messages: [{ role: 'user', content: prompt }],
+  });
+  return output;
+}

--- a/src/main/insights/queue.ts
+++ b/src/main/insights/queue.ts
@@ -1,0 +1,62 @@
+import { summarizeSession } from '../ai/insights-summarizer';
+import { getUnsummarizedSessions } from '../db';
+import { getApiKey, getSettings } from '../settings';
+
+const pending: number[] = [];
+let processing = false;
+
+export function enqueueSummary(sessionId: number): void {
+  pending.push(sessionId);
+  void processQueue();
+}
+
+async function processQueue(): Promise<void> {
+  if (processing || pending.length === 0) return;
+  processing = true;
+  try {
+    while (pending.length > 0) {
+      const id = pending.shift();
+      if (id === undefined) break;
+      await summarizeOne(id);
+      await delay(500);
+    }
+  } finally {
+    processing = false;
+  }
+}
+
+async function summarizeOne(sessionId: number): Promise<void> {
+  const apiKey = getApiKey();
+  if (!apiKey) {
+    console.log('[insights-queue] skipping session summary: no API key');
+    return;
+  }
+  const { model } = getSettings();
+  try {
+    const { getSessionById } = await import('../db');
+    const session = getSessionById(sessionId);
+    if (!session) return;
+    if (session.summary) return;
+    await summarizeSession(session, apiKey, model);
+    console.log(`[insights-queue] summarized session ${sessionId}`);
+  } catch (err) {
+    console.log(
+      `[insights-queue] failed to summarize session ${sessionId}:`,
+      err,
+    );
+  }
+}
+
+export function backfillUnsummarized(): void {
+  const sessions = getUnsummarizedSessions(50);
+  for (const s of sessions) {
+    if (!pending.includes(s.id)) {
+      pending.push(s.id);
+    }
+  }
+  void processQueue();
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/src/main/insights/sessions.ts
+++ b/src/main/insights/sessions.ts
@@ -1,0 +1,162 @@
+import type { Category, Sample, Session } from '../../shared/types';
+import { insertSession, updateSession } from '../db';
+import { createEmitter } from '../emitter';
+
+const IDLE_GAP_MS = 2 * 60 * 1000;
+const SOFT_BREAK_COUNT = 3;
+const CONTINUITY_THRESHOLD = 0.5;
+
+interface OpenSession {
+  dbSession: Session;
+  categoryCounts: Record<string, number>;
+  projectCounts: Record<string, number>;
+  appCounts: Record<string, number>;
+  divergentRun: number;
+  lastSampleTs: number;
+}
+
+let open: OpenSession | null = null;
+
+const sessionClosedEmitter = createEmitter<Session>();
+export const onSessionClosed = sessionClosedEmitter.on;
+
+function continuity(a: Sample, b: Sample): number {
+  let score = 0;
+  if (a.category === b.category) score += 0.5;
+  if (a.project === b.project) score += 0.3;
+  if (a.focusedApp === b.focusedApp) score += 0.2;
+  return score;
+}
+
+function dominant<T extends string>(counts: Record<string, number>): T {
+  let best = '' as T;
+  let max = -1;
+  for (const [key, count] of Object.entries(counts)) {
+    if (count > max) {
+      max = count;
+      best = key as T;
+    }
+  }
+  return best;
+}
+
+function buildCategoryMix(
+  counts: Record<string, number>,
+): Record<string, number> {
+  const total = Object.values(counts).reduce((a, b) => a + b, 0);
+  if (total === 0) return {};
+  const mix: Record<string, number> = {};
+  for (const [cat, count] of Object.entries(counts)) {
+    mix[cat] = Math.round((count / total) * 100);
+  }
+  return mix;
+}
+
+function startNewSession(sample: Sample): void {
+  const categoryCounts: Record<string, number> = {};
+  const projectCounts: Record<string, number> = {};
+  const appCounts: Record<string, number> = {};
+
+  categoryCounts[sample.category] = 1;
+  if (sample.project) projectCounts[sample.project] = 1;
+  if (sample.focusedApp) appCounts[sample.focusedApp] = 1;
+
+  const dbSession = insertSession({
+    startTs: sample.ts,
+    endTs: sample.ts,
+    durationMs: 0,
+    primaryCategory: sample.category,
+    primaryProject: sample.project,
+    primaryApp: sample.focusedApp,
+    sampleCount: 1,
+    categoryMix: { [sample.category]: 100 },
+  });
+
+  open = {
+    dbSession,
+    categoryCounts,
+    projectCounts,
+    appCounts,
+    divergentRun: 0,
+    lastSampleTs: sample.ts,
+  };
+}
+
+function closeCurrentSession(): Session | null {
+  if (!open) return null;
+  const closed = open.dbSession;
+  open = null;
+  sessionClosedEmitter.emit(closed);
+  return closed;
+}
+
+function extendSession(o: OpenSession, sample: Sample): void {
+  o.categoryCounts[sample.category] =
+    (o.categoryCounts[sample.category] ?? 0) + 1;
+  if (sample.project) {
+    o.projectCounts[sample.project] =
+      (o.projectCounts[sample.project] ?? 0) + 1;
+  }
+  if (sample.focusedApp) {
+    o.appCounts[sample.focusedApp] = (o.appCounts[sample.focusedApp] ?? 0) + 1;
+  }
+
+  const sampleCount = o.dbSession.sampleCount + 1;
+  const endTs = sample.ts;
+  const durationMs = endTs - o.dbSession.startTs;
+
+  o.dbSession = {
+    ...o.dbSession,
+    endTs,
+    durationMs,
+    sampleCount,
+    primaryCategory: dominant<Category>(o.categoryCounts),
+    primaryProject: dominant(o.projectCounts) || null,
+    primaryApp: dominant(o.appCounts) || null,
+    categoryMix: buildCategoryMix(o.categoryCounts),
+  };
+  o.lastSampleTs = sample.ts;
+
+  updateSession(o.dbSession);
+}
+
+let lastSample: Sample | null = null;
+
+export function trackSample(sample: Sample): void {
+  if (!open) {
+    startNewSession(sample);
+    lastSample = sample;
+    return;
+  }
+
+  const gap = sample.ts - open.lastSampleTs;
+  if (gap > IDLE_GAP_MS) {
+    closeCurrentSession();
+    startNewSession(sample);
+    lastSample = sample;
+    return;
+  }
+
+  if (lastSample) {
+    const score = continuity(lastSample, sample);
+    if (score < CONTINUITY_THRESHOLD) {
+      open.divergentRun++;
+    } else {
+      open.divergentRun = 0;
+    }
+  }
+
+  if (open.divergentRun >= SOFT_BREAK_COUNT) {
+    closeCurrentSession();
+    startNewSession(sample);
+    lastSample = sample;
+    return;
+  }
+
+  extendSession(open, sample);
+  lastSample = sample;
+}
+
+export function flushOpenSession(): Session | null {
+  return closeCurrentSession();
+}

--- a/src/main/insights/summaries.ts
+++ b/src/main/insights/summaries.ts
@@ -1,0 +1,200 @@
+import type { DaySummary, MonthSummary, WeekSummary } from '../../shared/types';
+import {
+  generateDaySummary,
+  generateMonthSummary,
+  generateWeekSummary,
+} from '../ai/insights-summarizer';
+import { getDb, getSessions } from '../db';
+import { getApiKey, getSettings } from '../settings';
+
+function readSummary(key: string): { json: string; stale: boolean } | null {
+  const row = getDb()
+    .prepare('SELECT summary_json, stale FROM summaries WHERE key = ?')
+    .get(key) as { summary_json: string; stale: number } | undefined;
+  if (!row) return null;
+  return { json: row.summary_json, stale: row.stale === 1 };
+}
+
+function writeSummary(key: string, level: string, json: string): void {
+  getDb()
+    .prepare(
+      'INSERT OR REPLACE INTO summaries (key, level, summary_json, generated_ts, stale) VALUES (?, ?, ?, ?, 0)',
+    )
+    .run(key, level, json, Date.now());
+}
+
+export function markStaleDaySummary(date: string): void {
+  getDb()
+    .prepare('UPDATE summaries SET stale = 1 WHERE key = ?')
+    .run(`day:${date}`);
+  const weekKey = dateToWeekKey(date);
+  getDb()
+    .prepare('UPDATE summaries SET stale = 1 WHERE key = ?')
+    .run(`week:${weekKey}`);
+  const monthKey = date.slice(0, 7);
+  getDb()
+    .prepare('UPDATE summaries SET stale = 1 WHERE key = ?')
+    .run(`month:${monthKey}`);
+}
+
+function dateToWeekKey(dateStr: string): string {
+  const d = new Date(`${dateStr}T00:00:00`);
+  const jan1 = new Date(d.getFullYear(), 0, 1);
+  const dayOfYear = Math.floor((d.getTime() - jan1.getTime()) / 86400000) + 1;
+  const weekNum = Math.ceil((dayOfYear + ((jan1.getDay() + 6) % 7)) / 7);
+  return `${d.getFullYear()}-W${String(weekNum).padStart(2, '0')}`;
+}
+
+function dayRange(date: string): { start: number; end: number } {
+  const start = new Date(`${date}T00:00:00`).getTime();
+  const end = start + 86400000;
+  return { start, end };
+}
+
+export async function getDaySummary(date: string): Promise<DaySummary> {
+  const { start, end } = dayRange(date);
+  const sessions = getSessions(start, end);
+
+  const cached = readSummary(`day:${date}`);
+  if (cached && !cached.stale) {
+    return { date, ...JSON.parse(cached.json), sessions };
+  }
+
+  const apiKey = getApiKey();
+  if (!apiKey || sessions.length === 0) {
+    return {
+      date,
+      highlights: [],
+      topProjects: [],
+      patterns: [],
+      categoryBreakdown: [],
+      sessions,
+    };
+  }
+
+  const { model } = getSettings();
+  const result = await generateDaySummary(date, sessions, apiKey, model);
+  writeSummary(`day:${date}`, 'day', JSON.stringify(result));
+  return { date, ...result, sessions };
+}
+
+export async function getWeekSummary(week: string): Promise<WeekSummary> {
+  const cached = readSummary(`week:${week}`);
+  if (cached && !cached.stale) {
+    return { week, ...JSON.parse(cached.json) };
+  }
+
+  const dates = weekToDates(week);
+  const daySummaries: { date: string; json: Omit<DaySummary, 'sessions'> }[] =
+    [];
+  for (const date of dates) {
+    const ds = await getDaySummary(date);
+    const { sessions: _, ...rest } = ds;
+    daySummaries.push({ date, json: rest });
+  }
+
+  const nonEmpty = daySummaries.filter((d) => d.json.highlights.length > 0);
+  if (nonEmpty.length === 0) {
+    return {
+      week,
+      highlights: [],
+      topProjects: [],
+      trends: [],
+      dailyBreakdown: [],
+    };
+  }
+
+  const apiKey = getApiKey();
+  if (!apiKey) {
+    return {
+      week,
+      highlights: [],
+      topProjects: [],
+      trends: [],
+      dailyBreakdown: [],
+    };
+  }
+
+  const { model } = getSettings();
+  const result = await generateWeekSummary(week, nonEmpty, apiKey, model);
+  writeSummary(`week:${week}`, 'week', JSON.stringify(result));
+  return { week, ...result };
+}
+
+export async function getMonthSummary(month: string): Promise<MonthSummary> {
+  const cached = readSummary(`month:${month}`);
+  if (cached && !cached.stale) {
+    return { month, ...JSON.parse(cached.json) };
+  }
+
+  const weeks = monthToWeeks(month);
+  const weekSummaries: {
+    week: string;
+    json: WeekSummary;
+  }[] = [];
+  for (const week of weeks) {
+    const ws = await getWeekSummary(week);
+    weekSummaries.push({ week, json: ws });
+  }
+
+  const nonEmpty = weekSummaries.filter((w) => w.json.highlights.length > 0);
+  if (nonEmpty.length === 0) {
+    return {
+      month,
+      highlights: [],
+      topProjects: [],
+      trends: [],
+      weeklyBreakdown: [],
+    };
+  }
+
+  const apiKey = getApiKey();
+  if (!apiKey) {
+    return {
+      month,
+      highlights: [],
+      topProjects: [],
+      trends: [],
+      weeklyBreakdown: [],
+    };
+  }
+
+  const { model } = getSettings();
+  const result = await generateMonthSummary(month, nonEmpty, apiKey, model);
+  writeSummary(`month:${month}`, 'month', JSON.stringify(result));
+  return { month, ...result };
+}
+
+function weekToDates(week: string): string[] {
+  const [yearStr, weekStr] = week.split('-W');
+  const year = Number(yearStr);
+  const weekNum = Number(weekStr);
+  // ISO 8601: week 1 contains January 4
+  const jan4 = new Date(year, 0, 4);
+  const dayOfWeek = (jan4.getDay() + 6) % 7;
+  const monday = new Date(jan4);
+  monday.setDate(jan4.getDate() - dayOfWeek + (weekNum - 1) * 7);
+
+  const dates: string[] = [];
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(monday);
+    d.setDate(monday.getDate() + i);
+    dates.push(d.toISOString().slice(0, 10));
+  }
+  return dates;
+}
+
+function monthToWeeks(month: string): string[] {
+  const [yearStr, monthStr] = month.split('-');
+  const year = Number(yearStr);
+  const monthNum = Number(monthStr) - 1;
+  const weeks = new Set<string>();
+
+  const daysInMonth = new Date(year, monthNum + 1, 0).getDate();
+  for (let day = 1; day <= daysInMonth; day++) {
+    const d = new Date(year, monthNum, day);
+    const weekKey = dateToWeekKey(d.toISOString().slice(0, 10));
+    weeks.add(weekKey);
+  }
+  return [...weeks].sort();
+}

--- a/src/renderer/views/Insights.tsx
+++ b/src/renderer/views/Insights.tsx
@@ -1,0 +1,600 @@
+import type {
+  Category,
+  DaySummary,
+  MonthSummary,
+  Session,
+  WeekSummary,
+} from '@shared/types';
+import { ChevronLeft, ChevronRight, RefreshCw } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useMountEffect } from '@/hooks/use-mount-effect';
+import { CATEGORY_COLORS } from '@/lib/categories';
+
+type Tab = 'day' | 'week' | 'month';
+
+export function Insights() {
+  const [tab, setTab] = useState<Tab>('day');
+  const [date, setDate] = useState(() => todayStr());
+  const [week, setWeek] = useState(() => currentWeekStr());
+  const [month, setMonth] = useState(() => currentMonthStr());
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex items-center justify-between">
+        <h2 className="font-semibold text-lg">Insights</h2>
+        <div className="flex items-center gap-1">
+          {(['day', 'week', 'month'] as const).map((t) => (
+            <Button
+              key={t}
+              variant={tab === t ? 'default' : 'ghost'}
+              size="sm"
+              onClick={() => setTab(t)}
+            >
+              {t.charAt(0).toUpperCase() + t.slice(1)}
+            </Button>
+          ))}
+        </div>
+      </div>
+      <div className="mt-4 min-h-0 flex-1 overflow-y-auto">
+        {tab === 'day' && <DayView date={date} onDateChange={setDate} />}
+        {tab === 'week' && <WeekView week={week} onWeekChange={setWeek} />}
+        {tab === 'month' && (
+          <MonthView month={month} onMonthChange={setMonth} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DayView({
+  date,
+  onDateChange,
+}: {
+  date: string;
+  onDateChange: (d: string) => void;
+}) {
+  const [summary, setSummary] = useState<DaySummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  useMountEffect(() => {
+    loadDay(date, setSummary, setLoading);
+  });
+
+  const handleDateChange = (delta: number) => {
+    const d = new Date(`${date}T00:00:00`);
+    d.setDate(d.getDate() + delta);
+    const next = d.toISOString().slice(0, 10);
+    onDateChange(next);
+    loadDay(next, setSummary, setLoading);
+  };
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    try {
+      const result = await window.slowblink.refreshInsights(`day:${date}`);
+      if (result) setSummary(result);
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  if (loading) return <InsightsLoading />;
+  if (!summary || summary.sessions.length === 0) {
+    return <EmptyState label={`No data for ${formatDate(date)}`} />;
+  }
+
+  const totalMinutes = Math.round(
+    summary.sessions.reduce((a, s) => a + s.durationMs, 0) / 60000,
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => handleDateChange(-1)}
+          >
+            <ChevronLeft className="size-4" />
+          </Button>
+          <span className="font-medium text-sm">{formatDate(date)}</span>
+          <Button variant="ghost" size="sm" onClick={() => handleDateChange(1)}>
+            <ChevronRight className="size-4" />
+          </Button>
+        </div>
+        <div className="flex items-center gap-2 text-muted-foreground text-sm">
+          <span>{totalMinutes} min tracked</span>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleRefresh}
+            disabled={refreshing}
+          >
+            <RefreshCw
+              className={`size-4 ${refreshing ? 'animate-spin' : ''}`}
+            />
+          </Button>
+        </div>
+      </div>
+
+      {summary.highlights.length > 0 && (
+        <Card className="p-4">
+          <h3 className="mb-2 font-medium text-sm">Highlights</h3>
+          <ul className="space-y-1 text-sm">
+            {summary.highlights.map((h) => (
+              <li key={h} className="text-muted-foreground">
+                {h}
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+
+      {summary.topProjects.length > 0 && (
+        <Card className="p-4">
+          <h3 className="mb-2 font-medium text-sm">Top Projects</h3>
+          <div className="space-y-2">
+            {summary.topProjects.map((p) => (
+              <div
+                key={p.project}
+                className="flex items-center justify-between"
+              >
+                <div>
+                  <span className="font-medium text-sm">{p.project}</span>
+                  <p className="text-muted-foreground text-xs">
+                    {p.description}
+                  </p>
+                </div>
+                <span className="text-muted-foreground text-sm tabular-nums">
+                  {p.durationMinutes}m
+                </span>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+
+      {summary.patterns.length > 0 && (
+        <Card className="p-4">
+          <h3 className="mb-2 font-medium text-sm">Patterns</h3>
+          <ul className="space-y-1 text-sm">
+            {summary.patterns.map((p) => (
+              <li key={p} className="text-muted-foreground">
+                {p}
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+
+      {summary.categoryBreakdown.length > 0 && (
+        <Card className="p-4">
+          <h3 className="mb-2 font-medium text-sm">Category Breakdown</h3>
+          <CategoryBar breakdown={summary.categoryBreakdown} />
+        </Card>
+      )}
+
+      <div>
+        <h3 className="mb-2 font-medium text-sm">Sessions</h3>
+        <div className="space-y-2">
+          {summary.sessions.map((s) => (
+            <SessionCard key={s.id} session={s} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WeekView({
+  week,
+  onWeekChange,
+}: {
+  week: string;
+  onWeekChange: (w: string) => void;
+}) {
+  const [summary, setSummary] = useState<WeekSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useMountEffect(() => {
+    loadWeek(week, setSummary, setLoading);
+  });
+
+  const handleWeekChange = (delta: number) => {
+    const next = shiftWeek(week, delta);
+    onWeekChange(next);
+    loadWeek(next, setSummary, setLoading);
+  };
+
+  if (loading) return <InsightsLoading />;
+  if (!summary || summary.highlights.length === 0) {
+    return <EmptyState label={`No data for ${week}`} />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-2">
+        <Button variant="ghost" size="sm" onClick={() => handleWeekChange(-1)}>
+          <ChevronLeft className="size-4" />
+        </Button>
+        <span className="font-medium text-sm">{week}</span>
+        <Button variant="ghost" size="sm" onClick={() => handleWeekChange(1)}>
+          <ChevronRight className="size-4" />
+        </Button>
+      </div>
+
+      {summary.highlights.length > 0 && (
+        <Card className="p-4">
+          <h3 className="mb-2 font-medium text-sm">Weekly Highlights</h3>
+          <ul className="space-y-1 text-sm">
+            {summary.highlights.map((h) => (
+              <li key={h} className="text-muted-foreground">
+                {h}
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+
+      {summary.topProjects.length > 0 && (
+        <Card className="p-4">
+          <h3 className="mb-2 font-medium text-sm">Top Projects</h3>
+          <div className="space-y-2">
+            {summary.topProjects.map((p) => (
+              <div
+                key={p.project}
+                className="flex items-center justify-between"
+              >
+                <div>
+                  <span className="font-medium text-sm">{p.project}</span>
+                  <p className="text-muted-foreground text-xs">
+                    {p.description}
+                  </p>
+                </div>
+                <span className="text-muted-foreground text-sm tabular-nums">
+                  {p.durationMinutes}m
+                </span>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+
+      {summary.trends.length > 0 && (
+        <Card className="p-4">
+          <h3 className="mb-2 font-medium text-sm">Trends</h3>
+          <ul className="space-y-1 text-sm">
+            {summary.trends.map((t) => (
+              <li key={t} className="text-muted-foreground">
+                {t}
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+
+      {summary.dailyBreakdown.length > 0 && (
+        <Card className="p-4">
+          <h3 className="mb-2 font-medium text-sm">Daily Breakdown</h3>
+          <div className="space-y-3">
+            {summary.dailyBreakdown.map((d) => (
+              <div key={d.date}>
+                <span className="font-medium text-xs">
+                  {formatDate(d.date)}
+                </span>
+                <ul className="mt-1 space-y-0.5">
+                  {d.highlights.map((h) => (
+                    <li key={h} className="text-muted-foreground text-xs">
+                      {h}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function MonthView({
+  month,
+  onMonthChange,
+}: {
+  month: string;
+  onMonthChange: (m: string) => void;
+}) {
+  const [summary, setSummary] = useState<MonthSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useMountEffect(() => {
+    loadMonth(month, setSummary, setLoading);
+  });
+
+  const handleMonthChange = (delta: number) => {
+    const [y, m] = month.split('-').map(Number);
+    const d = new Date(y, m - 1 + delta, 1);
+    const next = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+    onMonthChange(next);
+    loadMonth(next, setSummary, setLoading);
+  };
+
+  if (loading) return <InsightsLoading />;
+  if (!summary || summary.highlights.length === 0) {
+    return <EmptyState label={`No data for ${formatMonth(month)}`} />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-2">
+        <Button variant="ghost" size="sm" onClick={() => handleMonthChange(-1)}>
+          <ChevronLeft className="size-4" />
+        </Button>
+        <span className="font-medium text-sm">{formatMonth(month)}</span>
+        <Button variant="ghost" size="sm" onClick={() => handleMonthChange(1)}>
+          <ChevronRight className="size-4" />
+        </Button>
+      </div>
+
+      {summary.highlights.length > 0 && (
+        <Card className="p-4">
+          <h3 className="mb-2 font-medium text-sm">Monthly Highlights</h3>
+          <ul className="space-y-1 text-sm">
+            {summary.highlights.map((h) => (
+              <li key={h} className="text-muted-foreground">
+                {h}
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+
+      {summary.topProjects.length > 0 && (
+        <Card className="p-4">
+          <h3 className="mb-2 font-medium text-sm">Top Projects</h3>
+          <div className="space-y-2">
+            {summary.topProjects.map((p) => (
+              <div
+                key={p.project}
+                className="flex items-center justify-between"
+              >
+                <div>
+                  <span className="font-medium text-sm">{p.project}</span>
+                  <p className="text-muted-foreground text-xs">
+                    {p.description}
+                  </p>
+                </div>
+                <span className="text-muted-foreground text-sm tabular-nums">
+                  {p.durationMinutes}m
+                </span>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+
+      {summary.trends.length > 0 && (
+        <Card className="p-4">
+          <h3 className="mb-2 font-medium text-sm">Trends</h3>
+          <ul className="space-y-1 text-sm">
+            {summary.trends.map((t) => (
+              <li key={t} className="text-muted-foreground">
+                {t}
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+
+      {summary.weeklyBreakdown.length > 0 && (
+        <Card className="p-4">
+          <h3 className="mb-2 font-medium text-sm">Weekly Breakdown</h3>
+          <div className="space-y-3">
+            {summary.weeklyBreakdown.map((w) => (
+              <div key={w.week}>
+                <span className="font-medium text-xs">{w.week}</span>
+                <ul className="mt-1 space-y-0.5">
+                  {w.highlights.map((h) => (
+                    <li key={h} className="text-muted-foreground text-xs">
+                      {h}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function SessionCard({ session }: { session: Session }) {
+  const start = new Date(session.startTs).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  const end = new Date(session.endTs).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  const dur = Math.round(session.durationMs / 60000);
+  const color =
+    CATEGORY_COLORS[session.primaryCategory as Category] ?? 'bg-zinc-500';
+
+  return (
+    <Card className="flex items-start gap-3 p-3">
+      <span className={`mt-1 size-3 shrink-0 rounded-full ${color}`} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between text-muted-foreground text-xs">
+          <span>
+            {start} - {end}
+          </span>
+          <span className="tabular-nums">{dur}m</span>
+        </div>
+        <p className="mt-0.5 text-sm">
+          {session.summary ??
+            `${session.primaryCategory} in ${session.primaryApp ?? 'unknown'}`}
+        </p>
+        {session.primaryProject && (
+          <span className="mt-1 inline-block rounded bg-muted px-1.5 py-0.5 text-muted-foreground text-xs">
+            {session.primaryProject}
+          </span>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function CategoryBar({
+  breakdown,
+}: {
+  breakdown: { category: string; minutes: number }[];
+}) {
+  const total = breakdown.reduce((a, b) => a + b.minutes, 0);
+  if (total === 0) return null;
+
+  const sorted = [...breakdown].sort((a, b) => b.minutes - a.minutes);
+
+  return (
+    <div>
+      <div className="flex h-6 w-full overflow-hidden rounded">
+        {sorted.map(({ category, minutes }) => {
+          const pct = (minutes / total) * 100;
+          const color = CATEGORY_COLORS[category as Category] ?? 'bg-zinc-500';
+          return (
+            <div
+              key={category}
+              className={color}
+              style={{ width: `${pct}%` }}
+              title={`${category}: ${minutes}m`}
+            />
+          );
+        })}
+      </div>
+      <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs">
+        {sorted.map(({ category, minutes }) => (
+          <div key={category} className="flex items-center gap-1">
+            <span
+              className={`inline-block size-2 rounded-full ${CATEGORY_COLORS[category as Category] ?? 'bg-zinc-500'}`}
+            />
+            <span className="text-muted-foreground">
+              {category} ({minutes}m)
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function InsightsLoading() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-6 w-48" />
+      <Skeleton className="h-24 w-full" />
+      <Skeleton className="h-24 w-full" />
+    </div>
+  );
+}
+
+function EmptyState({ label }: { label: string }) {
+  return <p className="text-muted-foreground text-sm">{label}</p>;
+}
+
+function todayStr(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function currentWeekStr(): string {
+  const now = new Date();
+  const jan1 = new Date(now.getFullYear(), 0, 1);
+  const dayOfYear = Math.floor((now.getTime() - jan1.getTime()) / 86400000) + 1;
+  const weekNum = Math.ceil((dayOfYear + ((jan1.getDay() + 6) % 7)) / 7);
+  return `${now.getFullYear()}-W${String(weekNum).padStart(2, '0')}`;
+}
+
+function currentMonthStr(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function formatDate(date: string): string {
+  return new Date(`${date}T00:00:00`).toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatMonth(month: string): string {
+  const [y, m] = month.split('-');
+  return new Date(Number(y), Number(m) - 1, 1).toLocaleDateString(undefined, {
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+function shiftWeek(week: string, delta: number): string {
+  const [yearStr, weekStr] = week.split('-W');
+  const year = Number(yearStr);
+  const weekNum = Number(weekStr);
+  const jan4 = new Date(year, 0, 4);
+  const dayOfWeek = (jan4.getDay() + 6) % 7;
+  const monday = new Date(jan4);
+  monday.setDate(jan4.getDate() - dayOfWeek + (weekNum - 1) * 7);
+  monday.setDate(monday.getDate() + delta * 7);
+
+  const newJan1 = new Date(monday.getFullYear(), 0, 1);
+  const newDayOfYear =
+    Math.floor((monday.getTime() - newJan1.getTime()) / 86400000) + 1;
+  const newWeekNum = Math.ceil(
+    (newDayOfYear + ((newJan1.getDay() + 6) % 7)) / 7,
+  );
+  return `${monday.getFullYear()}-W${String(newWeekNum).padStart(2, '0')}`;
+}
+
+function loadDay(
+  date: string,
+  setSummary: (s: DaySummary | null) => void,
+  setLoading: (l: boolean) => void,
+) {
+  setLoading(true);
+  window.slowblink
+    .getDaySummary(date)
+    .then(setSummary)
+    .catch(() => setSummary(null))
+    .finally(() => setLoading(false));
+}
+
+function loadWeek(
+  week: string,
+  setSummary: (s: WeekSummary | null) => void,
+  setLoading: (l: boolean) => void,
+) {
+  setLoading(true);
+  window.slowblink
+    .getWeekSummary(week)
+    .then(setSummary)
+    .catch(() => setSummary(null))
+    .finally(() => setLoading(false));
+}
+
+function loadMonth(
+  month: string,
+  setSummary: (s: MonthSummary | null) => void,
+  setLoading: (l: boolean) => void,
+) {
+  setLoading(true);
+  window.slowblink
+    .getMonthSummary(month)
+    .then(setSummary)
+    .catch(() => setSummary(null))
+    .finally(() => setLoading(false));
+}


### PR DESCRIPTION
## Summary
- Archives untracked WIP for an **Insights** view (session/day/week/month summaries) that was sitting unstaged in the local main checkout.
- This idea was superseded on `main` by the merged **Overview** feature ([#13](https://github.com/AlanChen4/slowblink/pull/13)) — different file layout (\`src/main/overview/\`, \`Overview.tsx\`), different aggregation approach.
- Opened as a draft so the code isn't lost; close if there's nothing worth salvaging from the summarizer / session-queue logic.

## What's in here
- \`src/main/ai/insights-summarizer.ts\` — session + day/week/month LLM summarizer
- \`src/main/insights/{queue,sessions,summaries}.ts\` — session aggregation + summary queue
- \`src/renderer/views/Insights.tsx\` — day/week/month tabbed view

## Test plan
- [ ] Decide whether to salvage any logic from \`insights-summarizer.ts\` into the Overview pipeline
- [ ] Otherwise, close this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)