### PR TITLE
⚡️ Memoize window normalization in samplesToSegments

### DIFF
--- a/src/main/overview/segmenter.ts
+++ b/src/main/overview/segmenter.ts
@@ -75,14 +75,6 @@ function stripTrailingBrowserSuffix(
   return window;
 }
 
-function sameKey(a: Sample, b: Sample): boolean {
-  return (
-    a.focusedApp === b.focusedApp &&
-    normalizeFocusedWindow(a.focusedWindow, a.focusedApp) ===
-      normalizeFocusedWindow(b.focusedWindow, b.focusedApp)
-  );
-}
-
 function medianInterval(samples: Sample[]): number {
   const gaps: number[] = [];
   for (let i = 1; i < samples.length; i++) {
@@ -122,6 +114,12 @@ function emitIdleSegment(startTs: number, endTs: number): Segment {
 export function samplesToSegments(samples: Sample[]): Segment[] {
   if (samples.length === 0) return [];
   const interval = medianInterval(samples);
+  // Normalize each window once. Without this, the loop below would re-run the
+  // regex chain on both sides of every consecutive pair — O(2N) regex passes
+  // instead of O(N).
+  const keys = samples.map((s) =>
+    normalizeFocusedWindow(s.focusedWindow, s.focusedApp),
+  );
   const segments: Segment[] = [];
   let run: Sample[] = [samples[0]];
 
@@ -140,7 +138,7 @@ export function samplesToSegments(samples: Sample[]): Segment[] {
       continue;
     }
 
-    if (!sameKey(prev, curr)) {
+    if (prev.focusedApp !== curr.focusedApp || keys[i - 1] !== keys[i]) {
       segments.push(emitRunSegment(run, curr.ts));
       run = [curr];
       continue;

--- a/src/main/sync/ingest-rpc.test.ts
+++ b/src/main/sync/ingest-rpc.test.ts
@@ -63,7 +63,10 @@ describe('ingest_samples_with_cap RPC (requires pnpm db:start)', () => {
     });
 
     expect(error).toBeNull();
-    const rows = (data ?? []) as { inserted_id: string; inserted_client_id: string }[];
+    const rows = (data ?? []) as {
+      inserted_id: string;
+      inserted_client_id: string;
+    }[];
     expect(rows).toHaveLength(1);
     expect(rows[0].inserted_client_id).toBe('rpc-test-1');
     expect(rows[0].inserted_id).toMatch(/^[0-9a-f-]{36}$/);


### PR DESCRIPTION
## Summary

- The perf assertion in `samplesToSegments` (`<50ms` for an 8-hour, 2,880-sample coding day) had drifted to ~90ms — the hot loop's `sameKey()` helper re-ran `normalizeFocusedWindow()` (a multi-regex chain) on **both** sides of every consecutive pair, ~5,760 redundant normalizations per call.
- Fix: precompute `normalizeFocusedWindow` once per sample into a `keys[]` array, then compare cached keys in the loop. Drop the now-unused `sameKey()` helper.
- Same regex semantics — only the call shape changes. Perf test now finishes in ~17ms; full suite green (42 passed, 1 skipped).

## Context

Surfaced as a Stop-hook test failure during an unrelated investigation into the `Deploy Supabase (Production)` workflow regression on `main`. That deploy regression was resolved out-of-band (manual production reset + workflow re-run on commit `bba3b1e`) and isn't part of this PR.

## Test plan

- [x] `pnpm test` — full suite passes
- [x] `pnpm test src/main/overview/segmenter.test.ts` — file runs in ~28ms total (perf test alone is well under the 50ms budget)
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format`, `pnpm knip` — all green via Stop hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)