### PR TITLE
👷 Export APPLE_API_KEY path so notarization sees the .p8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,8 +79,9 @@ jobs:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         run: |
           mkdir -p ~/.appstoreconnect/private_keys
-          echo "$APPLE_API_KEY_BASE64" | base64 --decode \
-            > "$HOME/.appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8"
+          KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8"
+          echo "$APPLE_API_KEY_BASE64" | base64 --decode > "$KEY_PATH"
+          echo "APPLE_API_KEY=$KEY_PATH" >> "$GITHUB_ENV"
 
       - name: Build, sign, notarize
         env:


### PR DESCRIPTION
## Summary

The latest manual `Release` dry-run ([run 25513831561](https://github.com/AlanChen4/slowblink/actions/runs/25513831561)) failed at the **Build, sign, notarize** step with:

```
⨯ Env vars APPLE_API_KEY, APPLE_API_KEY_ID and APPLE_API_ISSUER need to be set
```

`APPLE_API_KEY` is **not** another GitHub secret — it's the **filesystem path** to the decoded `.p8` key on the runner. The "Install ASC API key" step decoded the file but never exported a path env var, so notarization had no way to find it.

## What changed

In `.github/workflows/release.yml`, the install step now appends `APPLE_API_KEY=<path>` to `$GITHUB_ENV` after writing the `.p8` file. This mirrors the `CSC_LINK` pattern used two steps earlier for the signing cert. No new secrets needed; existing `APPLE_API_KEY_BASE64` already contains the key contents.

```diff
-          echo "$APPLE_API_KEY_BASE64" | base64 --decode \
-            > "$HOME/.appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8"
+          KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY_ID}.p8"
+          echo "$APPLE_API_KEY_BASE64" | base64 --decode > "$KEY_PATH"
+          echo "APPLE_API_KEY=$KEY_PATH" >> "$GITHUB_ENV"
```

## Test plan

- [x] Dry run triggered on this branch: [run 25518834646](https://github.com/AlanChen4/slowblink/actions/runs/25518834646)
- [ ] "Build, sign, notarize" step gets past `signing` into `notarizing` (no more env-var error)
- [ ] "Upload dry-run artifact" succeeds with a `.dmg`
- [ ] Downloaded artifact passes `spctl --assess --type execute -vv slowblink.app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)